### PR TITLE
Add retry payment functionality for subscriptions and transactions

### DIFF
--- a/src/routes/x/loc/subscriptions/retryPayment.ts
+++ b/src/routes/x/loc/subscriptions/retryPayment.ts
@@ -1,0 +1,86 @@
+import { db } from "@/db/db";
+import { paymentQueue } from "@/queues/payments";
+import { transactions } from "@subtrees/schemas";
+import type Elysia from "elysia";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { RETRYABLE_SUBSCRIPTION_STATUSES, resolveGatewayPaymentId, resolveGatewayService } from "./shared";
+
+export async function retrySubscriptionPaymentRoutes(app: Elysia) {
+    return app.post("/:sid/payment/retry", async ({ params, status }) => {
+        const { lid, sid } = params as { lid: string; sid: string };
+
+        const sub = await db.query.memberSubscriptions.findFirst({
+            where: (s, { and, eq }) => and(eq(s.id, sid), eq(s.locationId, lid)),
+            columns: { id: true, status: true, cancelAt: true },
+        });
+
+        if (!sub) {
+            return status(404, { error: "Subscription not found", code: "SUBSCRIPTION_NOT_FOUND" });
+        }
+
+        if (!RETRYABLE_SUBSCRIPTION_STATUSES.has(sub.status)) {
+            return status(400, {
+                error: "Only past due or unpaid subscriptions can be retried",
+                code: "SUBSCRIPTION_NOT_RETRYABLE",
+            });
+        }
+
+        if (sub.cancelAt && sub.cancelAt.getTime() <= Date.now()) {
+            return status(400, {
+                error: "Canceled subscriptions cannot be retried",
+                code: "SUBSCRIPTION_CANCELED",
+            });
+        }
+
+        const [failedTransaction] = await db
+            .select({
+                id: transactions.id,
+                paymentIntentId: transactions.paymentIntentId,
+                metadata: transactions.metadata,
+            })
+            .from(transactions)
+            .where(and(
+                eq(transactions.locationId, lid),
+                eq(transactions.status, "failed"),
+                eq(transactions.type, "inbound"),
+                sql`(${transactions.metadata}->>'memberSubscriptionId' = ${sid} OR ${transactions.metadata}->>'subscriptionId' = ${sid})`,
+            ))
+            .orderBy(desc(transactions.chargeDate), desc(transactions.created))
+            .limit(1);
+
+        if (!failedTransaction) {
+            return status(400, {
+                error: "No failed transaction found for this subscription",
+                code: "FAILED_TRANSACTION_NOT_FOUND",
+            });
+        }
+
+        const metadata = failedTransaction.metadata;
+        const paymentIntentId = resolveGatewayPaymentId({
+            paymentIntentId: failedTransaction.paymentIntentId,
+            metadata,
+        });
+
+        if (!paymentIntentId) {
+            return status(400, {
+                error: "No gateway payment id found for latest failed transaction",
+                code: "GATEWAY_PAYMENT_ID_MISSING",
+            });
+        }
+
+        const jobId = `manual-retry-${failedTransaction.id}`;
+        const job = await paymentQueue.add("retry:sub", {
+            paymentIntentId,
+            attempts: 0,
+            subId: sid,
+            lid,
+        }, { jobId });
+
+        return status(200, {
+            enqueued: true,
+            jobId: job.id || jobId,
+            transactionId: failedTransaction.id,
+            gatewayService: resolveGatewayService(metadata),
+        });
+    });
+}

--- a/src/routes/x/loc/subscriptions/root.ts
+++ b/src/routes/x/loc/subscriptions/root.ts
@@ -6,6 +6,7 @@ import { createSubscriptionRoutes } from "./create";
 import { subscriptionMakeupCreditsRoutes } from "./makeupCredits";
 import { pauseSubscriptionRoutes } from "./pause";
 import { resumeSubscriptionRoutes } from "./resume";
+import { retrySubscriptionPaymentRoutes } from "./retryPayment";
 import { updateSubscriptionRoutes } from "./update";
 
 export const xSubscriptions = new Elysia({ prefix: "/subscriptions" })
@@ -16,4 +17,5 @@ export const xSubscriptions = new Elysia({ prefix: "/subscriptions" })
     .use(resumeSubscriptionRoutes)
     .use(updateSubscriptionRoutes)
     .use(cancelSubscriptionRoutes)
+    .use(retrySubscriptionPaymentRoutes)
     .use(subscriptionMakeupCreditsRoutes);

--- a/src/routes/x/loc/subscriptions/shared.ts
+++ b/src/routes/x/loc/subscriptions/shared.ts
@@ -38,3 +38,25 @@ export function getNextBillingDate(sub: {
     }
     return sub.currentPeriodEnd;
 }
+
+type TransactionMetadata = Record<string, unknown>;
+
+export const RETRYABLE_SUBSCRIPTION_STATUSES = new Set(["past_due", "unpaid"]);
+
+export function getString(value: unknown): string | null {
+    return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function resolveGatewayService(metadata: TransactionMetadata): "stripe" | "square" {
+    return metadata.gatewayService === "square" || getString(metadata.squarePaymentId) ? "square" : "stripe";
+}
+
+export function resolveGatewayPaymentId(transaction: {
+    paymentIntentId: string | null;
+    metadata: TransactionMetadata;
+}): string | null {
+    return transaction.paymentIntentId
+        || getString(transaction.metadata.paymentIntentId)
+        || getString(transaction.metadata.squarePaymentId)
+        || getString(transaction.metadata.chargeId);
+}

--- a/src/routes/x/loc/transactions/retry.ts
+++ b/src/routes/x/loc/transactions/retry.ts
@@ -1,0 +1,92 @@
+import { db } from "@/db/db";
+import { paymentQueue } from "@/queues/payments";
+import type Elysia from "elysia";
+import { and, eq } from "drizzle-orm";
+import {
+    RETRYABLE_SUBSCRIPTION_STATUSES,
+    getString,
+    resolveGatewayPaymentId,
+    resolveGatewayService,
+} from "../subscriptions/shared";
+
+export async function retryTransactionRoutes(app: Elysia) {
+    return app.post("/:tid/retry", async ({ params, status }) => {
+        const { lid, tid } = params as { lid: string; tid: string };
+
+        const tx = await db.query.transactions.findFirst({
+            where: (t, { and, eq }) => and(eq(t.id, tid), eq(t.locationId, lid)),
+            columns: { id: true, type: true, status: true, paymentIntentId: true, metadata: true },
+        });
+
+        if (!tx) {
+            return status(404, { error: "Transaction not found", code: "TRANSACTION_NOT_FOUND" });
+        }
+
+        if (tx.type !== "inbound" || tx.status !== "failed") {
+            return status(400, {
+                error: "Only failed inbound transactions can be retried",
+                code: "TRANSACTION_NOT_RETRYABLE",
+            });
+        }
+
+        const subId = getString(tx.metadata.memberSubscriptionId)
+            || getString(tx.metadata.subscriptionId);
+
+        if (!subId) {
+            return status(400, {
+                error: "Package payment retry is not yet supported",
+                code: "PACKAGE_RETRY_NOT_SUPPORTED",
+            });
+        }
+
+        const sub = await db.query.memberSubscriptions.findFirst({
+            where: (s, { and, eq }) => and(eq(s.id, subId), eq(s.locationId, lid)),
+            columns: { id: true, status: true, cancelAt: true },
+        });
+
+        if (!sub) {
+            return status(404, { error: "Linked subscription not found", code: "SUBSCRIPTION_NOT_FOUND" });
+        }
+
+        if (!RETRYABLE_SUBSCRIPTION_STATUSES.has(sub.status)) {
+            return status(400, {
+                error: "Only past due or unpaid subscriptions can be retried",
+                code: "SUBSCRIPTION_NOT_RETRYABLE",
+            });
+        }
+
+        if (sub.cancelAt && sub.cancelAt.getTime() <= Date.now()) {
+            return status(400, {
+                error: "Canceled subscriptions cannot be retried",
+                code: "SUBSCRIPTION_CANCELED",
+            });
+        }
+
+        const paymentIntentId = resolveGatewayPaymentId({
+            paymentIntentId: tx.paymentIntentId,
+            metadata: tx.metadata,
+        });
+
+        if (!paymentIntentId) {
+            return status(400, {
+                error: "No gateway payment id found for this transaction",
+                code: "GATEWAY_PAYMENT_ID_MISSING",
+            });
+        }
+
+        const jobId = `manual-retry-${tx.id}`;
+        const job = await paymentQueue.add("retry:sub", {
+            paymentIntentId,
+            attempts: 0,
+            subId: sub.id,
+            lid,
+        }, { jobId });
+
+        return status(200, {
+            enqueued: true,
+            jobId: job.id || jobId,
+            transactionId: tx.id,
+            gatewayService: resolveGatewayService(tx.metadata),
+        });
+    });
+}

--- a/src/routes/x/loc/transactions/root.ts
+++ b/src/routes/x/loc/transactions/root.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from "elysia";
 import { and, eq, gte } from "drizzle-orm";
+import { retryTransactionRoutes } from "./retry";
 import { db } from "@/db/db";
 import {
     memberInvoices,
@@ -469,4 +470,5 @@ export const xTransactions = new Elysia({ prefix: "/transactions" })
             reason: t.Optional(t.String()),
             note: t.Optional(t.String()),
         }),
-    });
+    })
+    .use(retryTransactionRoutes);


### PR DESCRIPTION
- Implemented `retrySubscriptionPaymentRoutes` to handle retrying failed subscription payments.
- Added `retryTransactionRoutes` for retrying failed inbound transactions.
- Updated shared utilities to support retry logic and payment ID resolution.
- Integrated new routes into the existing subscription and transaction route handlers.